### PR TITLE
Remove liveness parameters from React Native bridge

### DIFF
--- a/android/src/main/java/com/voiceItRNLibrary/VoiceitModule.java
+++ b/android/src/main/java/com/voiceItRNLibrary/VoiceitModule.java
@@ -124,8 +124,8 @@ public class VoiceitModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void encapsulatedFaceVerification(String userId, String contentLanguage, Boolean liveness, Boolean audioLiveness, final Callback successCallback, final Callback failureCallback){
-        myVoiceIt.encapsulatedFaceVerification(getCurrentActivity(), userId, contentLanguage, liveness, audioLiveness,new JsonHttpResponseHandler(){
+    public void encapsulatedFaceVerification(String userId, String contentLanguage, final Callback successCallback, final Callback failureCallback){
+        myVoiceIt.encapsulatedFaceVerification(getCurrentActivity(), userId, contentLanguage, new JsonHttpResponseHandler(){
             @Override
             public void onSuccess(int statusCode, Header[] headers, JSONObject response) {
                 successCallback.invoke(response.toString());
@@ -156,8 +156,8 @@ public class VoiceitModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void encapsulatedVideoVerification(String userId, String contentLanguage, String phrase, Boolean liveness, Boolean audioLiveness, final Callback successCallback, final Callback failureCallback){
-        myVoiceIt.encapsulatedVideoVerification(getCurrentActivity(),userId,contentLanguage,phrase,liveness, audioLiveness, new JsonHttpResponseHandler(){
+    public void encapsulatedVideoVerification(String userId, String contentLanguage, String phrase, final Callback successCallback, final Callback failureCallback){
+        myVoiceIt.encapsulatedVideoVerification(getCurrentActivity(),userId,contentLanguage,phrase, new JsonHttpResponseHandler(){
             @Override
             public void onSuccess(int statusCode, Header[] headers, JSONObject response) {
                 successCallback.invoke(response.toString());

--- a/ios/Voiceit.m
+++ b/ios/Voiceit.m
@@ -79,14 +79,11 @@ voicePrintPhrase:(NSString*)voicePrintPhrase successCallback:(RCTResponseSenderB
 
 RCT_EXPORT_METHOD(encapsulatedFaceVerification:(NSString *)userId
     contentLanguage:(NSString *) contentLanguage
-    doLivenessDetection:(BOOL)doLivenessDetection
-    doAudioPrompts:(BOOL)doAudioPrompts
     successCallback:(RCTResponseSenderBlock)successCallback
     failureCallback:(RCTResponseSenderBlock)failureCallback)
 {
         dispatch_async(dispatch_get_main_queue(), ^(){
-    [myVoiceit encapsulatedFaceVerification: userId doLivenessDetection: doLivenessDetection
-                          doAudioPrompts: doAudioPrompts
+    [myVoiceit encapsulatedFaceVerification: userId
                          contentLanguage: contentLanguage
     userVerificationCancelled:^{
     }  userVerificationSuccessful:^(float faceConfidence, NSString * jsonResponse){
@@ -101,8 +98,6 @@ RCT_EXPORT_METHOD(encapsulatedFaceVerification:(NSString *)userId
 RCT_EXPORT_METHOD(encapsulatedVideoVerification:(NSString *)userId
   contentLanguage:(NSString*)contentLanguage
   voicePrintPhrase:(NSString*)voicePrintPhrase
-doLivenessDetection:(BOOL)doLivenessDetection
- doAudioPrompts:(BOOL)doAudioPrompts
 successCallback:(RCTResponseSenderBlock)successCallback
 failureCallback:(RCTResponseSenderBlock)failureCallback)
 {
@@ -110,8 +105,6 @@ failureCallback:(RCTResponseSenderBlock)failureCallback)
     [myVoiceit encapsulatedVideoVerification: userId
     contentLanguage:contentLanguage
    voicePrintPhrase:voicePrintPhrase
-   doLivenessDetection:doLivenessDetection
-     doAudioPrompts:doAudioPrompts
     userVerificationCancelled:^{
     }userVerificationSuccessful:^(float faceConfidence, float voiceConfidence, NSString * jsonResponse){
                        successCallback(@[jsonResponse]);


### PR DESCRIPTION
## Summary
- Remove `liveness` and `audioLiveness` Boolean params from `encapsulatedFaceVerification` and `encapsulatedVideoVerification` in Android bridge (`VoiceitModule.java`)
- Remove `doLivenessDetection` and `doAudioPrompts` params from iOS bridge (`Voiceit.m`)
- The underlying iOS and Android SDKs no longer expose liveness parameters

## Test plan
- [ ] Verify React Native bridge compiles with updated SDK dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)