### PR TITLE
Rebrand VoiceIt2 to VoiceIt3

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ Get the <a href="https://github.com/voiceittech/VoiceIt3-AndroidSDK#local-instal
 <ul>
  <li> Clone the Android-SDK repo
  <li> Open your main android project/folder in android studio, and navigate to File -> New -> Import Module
- <li> Select the Android SDK repo that you just cloned. Check off the app module, only include the voiceit2 module
+ <li> Select the Android SDK repo that you just cloned. Check off the app module, only include the voiceit3 module
  <li> Navigate to you local VoiceIt3-React-Native-SDK Folder
  <li> In the android/build.gradle, add 
   ```
-  implementation project(path: ':voiceit2')
+  implementation project(path: ':voiceit3')
   ```
   under dependencies 
 </ul>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -75,7 +75,7 @@ repositories {
 
 dependencies {
     //noinspection GradleDynamicVersion
-    implementation 'com.github.voiceittech:VoiceItApi2AndroidSDK:2.3.2'
+    implementation 'com.github.voiceittech:VoiceItApi3AndroidSDK:2.3.2'
     implementation 'com.facebook.react:react-native:+'  // From node_modules
 }
 

--- a/android/src/main/java/com/voiceItRNLibrary/VoiceitModule.java
+++ b/android/src/main/java/com/voiceItRNLibrary/VoiceitModule.java
@@ -5,7 +5,7 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.Callback;
-import com.voiceit.voiceit2.VoiceItAPI2;
+import com.voiceit.voiceit3.VoiceItAPI3;
 import org.json.JSONObject;
 import java.io.File;
 import cz.msebera.android.httpclient.Header;
@@ -15,7 +15,7 @@ import android.graphics.Color;
 public class VoiceitModule extends ReactContextBaseJavaModule {
 
     private final ReactApplicationContext reactContext;
-    private VoiceItAPI2 myVoiceIt;
+    private VoiceItAPI3 myVoiceIt;
 
     public VoiceitModule(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -29,25 +29,25 @@ public class VoiceitModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void initVoiceIt(String apiKey, String apiToken, String baseUrl, final Callback successCallback){
-        myVoiceIt = new VoiceItAPI2(apiKey, apiToken, baseUrl);
+        myVoiceIt = new VoiceItAPI3(apiKey, apiToken, baseUrl);
         successCallback.invoke("Initialized");
     }
 
     @ReactMethod
     public void initVoiceIt(String apiKey, String apiToken, String host, final Callback successCallback){
-        myVoiceIt = new VoiceItAPI2(apiKey, apiToken, host);
+        myVoiceIt = new VoiceItAPI3(apiKey, apiToken, host);
         successCallback.invoke("Initialized");
     }
 
     @ReactMethod
     public void initVoiceItWithTheme(String apiKey, String apiToken, String themeColor, final Callback successCallback){
-        myVoiceIt = new VoiceItAPI2(apiKey,apiToken, Color.parseColor(themeColor));
+        myVoiceIt = new VoiceItAPI3(apiKey,apiToken, Color.parseColor(themeColor));
         successCallback.invoke("Initialized");
     }
 
     @ReactMethod
     public void initVoiceItWithTheme(String apiKey, String apiToken, String themeColor, String host, final Callback successCallback){
-        myVoiceIt = new VoiceItAPI2(apiKey, apiToken, Color.parseColor(themeColor), host);
+        myVoiceIt = new VoiceItAPI3(apiKey, apiToken, Color.parseColor(themeColor), host);
 		myVoiceIt.setURL(baseUrl);
         successCallback.invoke("Initialized");
     }

--- a/ios/Voiceit.m
+++ b/ios/Voiceit.m
@@ -1,11 +1,11 @@
 #import "Voiceit.h"
-#import "VoiceItAPITwo.h"
+#import "VoiceItAPIThree.h"
 #import "React/RCTUtils.h"
 
 
 @implementation Voiceit
 
-VoiceItAPITwo *myVoiceit;
+VoiceItAPIThree *myVoiceit;
 
 RCT_EXPORT_MODULE()
 
@@ -13,7 +13,7 @@ RCT_EXPORT_METHOD(initVoiceIt:(NSString *)apiKey tokenParameter:(NSString *)apiT
 {
     UIViewController *presentedViewController = RCTPresentedViewController();
     // get the root view of the app and then pass it
-    myVoiceit = [[VoiceItAPITwo alloc] init: presentedViewController apiKey:apiKey apiToken:apiToken];
+    myVoiceit = [[VoiceItAPIThree alloc] init: presentedViewController apiKey:apiKey apiToken:apiToken];
     successCallback(@[@"Initialized"]);
 }
 
@@ -26,7 +26,7 @@ RCT_EXPORT_METHOD(initVoiceItWithTheme:(NSString *)apiKey tokenParameter:(NSStri
     [styles setObject:themeColor forKey:@"kThemeColor"];
     [styles setObject:@"default" forKey:@"kIconStyle"];
 
-    myVoiceit = [[VoiceItAPITwo alloc] init: presentedViewController apiKey:apiKey apiToken:apiToken styles: styles];
+    myVoiceit = [[VoiceItAPIThree alloc] init: presentedViewController apiKey:apiKey apiToken:apiToken styles: styles];
     successCallback(@[@"Initialized"]);
 }
 


### PR DESCRIPTION
## Summary
- Rename all VoiceIt2 references to VoiceIt3
- Update Android bridge imports (`VoiceItAPI2` → `VoiceItAPI3`)
- Update iOS bridge references (`VoiceItAPITwo` → `VoiceItAPIThree`)
- Update build.gradle dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)